### PR TITLE
Improve path validation

### DIFF
--- a/flash_tool.sh
+++ b/flash_tool.sh
@@ -35,7 +35,7 @@ while getopts "c:t:s:d:p:r:d:i:h" flag; do
 			;;
 		i)
 			IMAGE="$OPTARG"
-			if [ ! -e ${IMAGE} ]; then
+			if [ ! -f "${IMAGE}" ]; then
 				echo -e "\e[31m CAN'T FIND IMAGE \e[0m"
 				usage
 				exit
@@ -62,7 +62,7 @@ if [ ! $IMAGE ]; then
 	exit
 fi
 
-if [ ! -e ${EXTLINUXPATH}/${CHIP}.conf ]; then
+if [ ! -f "${EXTLINUXPATH}/${CHIP}.conf" ]; then
 	CHIP="rk3288"
 fi
 

--- a/mk-image.sh
+++ b/mk-image.sh
@@ -46,7 +46,7 @@ while getopts "c:t:s:r:h" flag; do
 done
 OPTIND=$OLD_OPTIND
 
-if [ ! -e ${EXTLINUXPATH}/${CHIP}.conf ]; then
+if [ ! -f "${EXTLINUXPATH}/${CHIP}.conf" ]; then
 	CHIP="rk3288"
 fi
 
@@ -72,6 +72,18 @@ generate_boot_image() {
 }
 
 generate_system_image() {
+	if [ ! -f "${OUT}/boot.img" ]; then
+		echo -e "\e[31m CAN'T FIND BOOT IMAGE \e[0m"
+		usage
+		exit
+	fi
+
+	if [ ! -f "${ROOTFS_PATH}" ]; then
+		echo -e "\e[31m CAN'T FIND ROOTFS IMAGE \e[0m"
+		usage
+		exit
+	fi
+
 	SYSTEM=${OUT}/system.img
 	rm -rf ${SYSTEM}
 
@@ -120,17 +132,9 @@ EOF
 	fi
 
 	# burn boot image
-	if [ ! -e ${OUT}/boot.img ]; then
-		echo -e "\e[31m CAN'T FIND BOOT IMAGE \e[0m"
-		exit
-	fi
 	dd if=${OUT}/boot.img of=${SYSTEM} conv=notrunc seek=${BOOT_START}
 
 	# burn rootfs image
-	if [ ! -e ${ROOTFS_PATH} ]; then
-		echo -e "\e[31m CAN'T FIND ROOTFS IMAGE \e[0m"
-		exit
-	fi
 	dd if=${ROOTFS_PATH} of=${SYSTEM} seek=${ROOTFS_START}
 }
 


### PR DESCRIPTION
* Validate boot and rootfs paths prior to starting work
* Ensure paths are files
* Quote variables to fix path validation; mostly applies to ROOTFS_PATH,
  since it could be empty, but other conditionals were changed for
  consistency:

  ```bash
  $ if [ ! -f ${ROOTFS_PATH} ]; then echo 'bad path'; fi
  $ if [ ! -f "${ROOTFS_PATH}" ]; then echo 'bad path'; fi
  bad path
  ```